### PR TITLE
Use same conventions in different clients

### DIFF
--- a/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/integration-test/java/eu/xenit/alfresco/solrapi/client/ditto/SolrApiDittoClientIntegrationTest.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/integration-test/java/eu/xenit/alfresco/solrapi/client/ditto/SolrApiDittoClientIntegrationTest.java
@@ -1,16 +1,15 @@
 package eu.xenit.alfresco.solrapi.client.ditto;
 
+import eu.xenit.alfresco.solrapi.client.spi.SolrApiClient;
 import eu.xenit.alfresco.solrapi.client.tests.GetMetadataIntegrationTests;
 import eu.xenit.alfresco.solrapi.client.tests.GetNodesIntegrationTests;
 import eu.xenit.alfresco.solrapi.client.tests.GetTransactionsIntegrationTests;
-import eu.xenit.alfresco.solrapi.client.spi.SolrApiClient;
 import eu.xenit.testing.ditto.api.AlfrescoDataSet;
 
-class SolrApiDittoClientIntegrationTest
-{
+class SolrApiDittoClientIntegrationTest {
 
     public SolrApiClient solrApiClient() {
-        return FakeSolrApiClient.builder()
+        return SolrApiFakeClient.builder()
                 .withDataSet(AlfrescoDataSet.bootstrapAlfresco().build())
                 .build();
     }

--- a/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/main/java/eu/xenit/alfresco/solrapi/client/ditto/SolrApiFakeClient.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/main/java/eu/xenit/alfresco/solrapi/client/ditto/SolrApiFakeClient.java
@@ -23,36 +23,34 @@ import eu.xenit.testing.ditto.api.data.ContentModel.Content;
 import eu.xenit.testing.ditto.api.model.MLText;
 import eu.xenit.testing.ditto.api.model.Node;
 import eu.xenit.testing.ditto.api.model.ParentChildAssoc;
-import eu.xenit.testing.ditto.api.model.ParentChildNodeCollection;
 import eu.xenit.testing.ditto.api.model.QName;
 import eu.xenit.testing.ditto.api.model.Transaction;
 import eu.xenit.testing.ditto.api.model.Transaction.Filters;
-
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Data;
 
-public class FakeSolrApiClient implements SolrApiClient {
+public class SolrApiFakeClient implements SolrApiClient {
 
     private final TransactionView txnView;
     private final NodeView nodeView;
 
-    private FakeSolrApiClient(Builder builder) {
+    private SolrApiFakeClient(Builder builder) {
         this(builder.data);
     }
 
-    FakeSolrApiClient(AlfrescoDataSet dataSet) {
+    SolrApiFakeClient(AlfrescoDataSet dataSet) {
         this(dataSet.getTransactionView(), dataSet.getNodeView());
     }
 
-    FakeSolrApiClient(TransactionView transactionView, NodeView nodeView) {
+    SolrApiFakeClient(TransactionView transactionView, NodeView nodeView) {
         this.txnView = transactionView;
         this.nodeView = nodeView;
     }
@@ -294,8 +292,8 @@ public class FakeSolrApiClient implements SolrApiClient {
 
         }
 
-        public FakeSolrApiClient build() {
-            return new FakeSolrApiClient(this);
+        public SolrApiFakeClient build() {
+            return new SolrApiFakeClient(this);
         }
 
         public Builder withDataSet(AlfrescoDataSet dataSet) {

--- a/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/test/java/eu/xenit/alfresco/solrapi/client/ditto/GetNodesMetadata.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/test/java/eu/xenit/alfresco/solrapi/client/ditto/GetNodesMetadata.java
@@ -45,7 +45,7 @@ public class GetNodesMetadata {
     @Test
     void getNodesMetadata_companyHome() {
 
-        SolrApiClient client = new FakeSolrApiClient(null, nodeViewMock());
+        SolrApiClient client = new SolrApiFakeClient(null, nodeViewMock());
         List<SolrNodeMetaData> nodesMetaData = client
                 .getNodesMetaData(new NodeMetaDataQueryParameters().withNodeIds(13L));
 
@@ -63,7 +63,7 @@ public class GetNodesMetadata {
     @Test
     void getNodesMetadata_companyHome_filterOutput() {
 
-        SolrApiClient client = new FakeSolrApiClient(null, nodeViewMock());
+        SolrApiClient client = new SolrApiFakeClient(null, nodeViewMock());
         List<SolrNodeMetaData> nodesMetaData = client
                 .getNodesMetaData(
                         new NodeMetaDataQueryParameters()
@@ -124,7 +124,7 @@ public class GetNodesMetadata {
                 })
                 .build();
 
-        SolrApiClient client = new FakeSolrApiClient(dataSet);
+        SolrApiClient client = new SolrApiFakeClient(dataSet);
         List<SolrNodeMetaData> nodesMetaData = client
                 .getNodesMetaData(new NodeMetaDataQueryParameters().withNodeIds(90L));
 

--- a/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/test/java/eu/xenit/alfresco/solrapi/client/ditto/GetNodesTests.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/test/java/eu/xenit/alfresco/solrapi/client/ditto/GetNodesTests.java
@@ -35,7 +35,7 @@ public class GetNodesTests {
     void testTxnIdsFilter() {
 
         TransactionView txnView = getTxnViewMock();
-        FakeSolrApiClient client = new FakeSolrApiClient(txnView, null);
+        SolrApiFakeClient client = new SolrApiFakeClient(txnView, null);
 
         List<SolrNode> nodes = client.getNodes(new NodesQueryParameters().withTxnIds(2L));
         assertThat(nodes)
@@ -47,7 +47,7 @@ public class GetNodesTests {
     void testTxnFromFilter() {
 
         TransactionView txnView = getTxnViewMock();
-        FakeSolrApiClient client = new FakeSolrApiClient(txnView, null);
+        SolrApiFakeClient client = new SolrApiFakeClient(txnView, null);
 
         List<SolrNode> nodes = client.getNodes(new NodesQueryParameters().setFromTxnId(3L));
         assertThat(nodes)
@@ -58,7 +58,7 @@ public class GetNodesTests {
     void testTxnToFilter() {
 
         TransactionView txnView = getTxnViewMock();
-        FakeSolrApiClient client = new FakeSolrApiClient(txnView, null);
+        SolrApiFakeClient client = new SolrApiFakeClient(txnView, null);
 
         List<SolrNode> nodes = client.getNodes(new NodesQueryParameters().setToTxnId(1L));
         assertThat(nodes)
@@ -69,7 +69,7 @@ public class GetNodesTests {
     void testNodeIdFromFilter() {
 
         TransactionView txnView = getTxnViewMock();
-        FakeSolrApiClient client = new FakeSolrApiClient(txnView, null);
+        SolrApiFakeClient client = new SolrApiFakeClient(txnView, null);
 
         List<SolrNode> nodes = client.getNodes(new NodesQueryParameters().setFromNodeId(8L));
         assertThat(nodes)
@@ -83,7 +83,7 @@ public class GetNodesTests {
     void testNodeIdToFilter() {
 
         TransactionView txnView = getTxnViewMock();
-        FakeSolrApiClient client = new FakeSolrApiClient(txnView, null);
+        SolrApiFakeClient client = new SolrApiFakeClient(txnView, null);
 
         List<SolrNode> nodes = client.getNodes(new NodesQueryParameters().setToNodeId(1L));
         assertThat(nodes)
@@ -97,7 +97,7 @@ public class GetNodesTests {
     void testCombinedFilter() {
 
         TransactionView txnView = getTxnViewMock();
-        FakeSolrApiClient client = new FakeSolrApiClient(txnView, null);
+        SolrApiFakeClient client = new SolrApiFakeClient(txnView, null);
 
         List<SolrNode> nodes = client.getNodes(new NodesQueryParameters()
                 .setFromTxnId(2L)

--- a/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/test/java/eu/xenit/alfresco/solrapi/client/ditto/GetTransactionTests.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/test/java/eu/xenit/alfresco/solrapi/client/ditto/GetTransactionTests.java
@@ -14,7 +14,7 @@ public class GetTransactionTests {
     public void testGetMaxTransactionId() {
         long maxTxnId = defaultDataSet.getTransactionView().getLastTxnId();
 
-        FakeSolrApiClient solrApiClient = new FakeSolrApiClient(defaultDataSet);
+        SolrApiFakeClient solrApiClient = new SolrApiFakeClient(defaultDataSet);
         SolrTransactions result = solrApiClient.getTransactions(null, null, null, null, 0);
 
         assertThat(result)

--- a/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/integration-test/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClientIntegrationTest.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/integration-test/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClientIntegrationTest.java
@@ -17,7 +17,7 @@ class SolrApiSpringClientIntegrationTest {
     public SolrApiClient solrApiClient() {
         try {
             SolrRequestFactory solrRequestFactory = new SolrRequestFactory(new SolrSslProperties());
-            return new SolrAPIClientImpl(solrApiProperties(), solrRequestFactory);
+            return new SolrApiSpringClient(solrApiProperties(), solrRequestFactory);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/integration-test/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClientIntegrationTest.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/integration-test/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClientIntegrationTest.java
@@ -1,12 +1,11 @@
 package eu.xenit.alfresco.solrapi.client.spring;
 
+import eu.xenit.alfresco.solrapi.client.spi.SolrApiClient;
 import eu.xenit.alfresco.solrapi.client.tests.GetMetadataIntegrationTests;
 import eu.xenit.alfresco.solrapi.client.tests.GetNodesIntegrationTests;
 import eu.xenit.alfresco.solrapi.client.tests.GetTransactionsIntegrationTests;
-import eu.xenit.alfresco.solrapi.client.spi.SolrApiClient;
 
-class SolrApiSpringClientIntegrationTest
-{
+class SolrApiSpringClientIntegrationTest {
 
     SolrApiProperties solrApiProperties() {
         return SolrApiProperties.builder()

--- a/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/integration-test/resources/logback-test.xml
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/integration-test/resources/logback-test.xml
@@ -9,7 +9,7 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="eu.xenit.alfresco.solrapi.client.spring.SolrAPIClientImpl" level="DEBUG"/>
+    <logger name="eu.xenit.alfresco.solrapi.client.spring.SolrApiSpringClient" level="DEBUG"/>
     <logger name="eu.xenit.alfresco.solrapi.client.spring.LogAsCurlRequestsInterceptor" level="DEBUG"/>
 
     <logger name="org.springframework.web.client.RestTemplate" level="DEBUG"/>

--- a/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/main/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClient.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/main/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClient.java
@@ -35,21 +35,21 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
-public class SolrAPIClientImpl implements SolrApiClient {
+public class SolrApiSpringClient implements SolrApiClient {
 
     private final RestTemplate restTemplate;
     private final String url;
 
-    public SolrAPIClientImpl(SolrApiProperties solrApiProperties, SolrSslProperties solrSslProperties)
+    public SolrApiSpringClient(SolrApiProperties solrApiProperties, SolrSslProperties solrSslProperties)
             throws GeneralSecurityException, IOException {
         this(solrApiProperties, new SolrRequestFactory(solrSslProperties));
     }
 
-    public SolrAPIClientImpl(SolrApiProperties solrProperties, ClientHttpRequestFactory requestFactory) {
+    public SolrApiSpringClient(SolrApiProperties solrProperties, ClientHttpRequestFactory requestFactory) {
         this(solrProperties, buildRestTemplate(requestFactory));
     }
 
-    public SolrAPIClientImpl(SolrApiProperties solrProperties, RestTemplate restTemplate) {
+    public SolrApiSpringClient(SolrApiProperties solrProperties, RestTemplate restTemplate) {
         this.url = UriComponentsBuilder.fromHttpUrl(solrProperties.getUrl())
                 .path("/service/api/solr")
                 .toUriString();

--- a/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/test/java/eu.xenit.alfresco.solrapi.client.spring/SolrApiSpringClientTest.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/test/java/eu.xenit.alfresco.solrapi.client.spring/SolrApiSpringClientTest.java
@@ -32,12 +32,12 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-class SolrAPIClientImplTest {
+class SolrApiSpringClientTest {
 
     @Test
     void getTransactions() {
         RestTemplate restTemplate = new RestTemplateBuilder().build();
-        SolrAPIClientImpl client = new SolrAPIClientImpl(new SolrApiProperties(), restTemplate);
+        SolrApiSpringClient client = new SolrApiSpringClient(new SolrApiProperties(), restTemplate);
 
         MockRestServiceServer.createServer(restTemplate)
                 .expect(requestUriPath("/alfresco/service/api/solr/transactions"))
@@ -79,7 +79,7 @@ class SolrAPIClientImplTest {
     void getNodes() {
 
         RestTemplate restTemplate = new RestTemplateBuilder().build();
-        SolrAPIClientImpl client = new SolrAPIClientImpl(new SolrApiProperties(), restTemplate);
+        SolrApiSpringClient client = new SolrApiSpringClient(new SolrApiProperties(), restTemplate);
 
         MockRestServiceServer.createServer(restTemplate)
                 .expect(requestUriPath("/alfresco/service/api/solr/nodes"))
@@ -122,7 +122,7 @@ class SolrAPIClientImplTest {
     void getNodesMetaData() {
 
         RestTemplate restTemplate = new RestTemplateBuilder().build();
-        SolrAPIClientImpl client = new SolrAPIClientImpl(new SolrApiProperties(), restTemplate);
+        SolrApiSpringClient client = new SolrApiSpringClient(new SolrApiProperties(), restTemplate);
 
         MockRestServiceServer.createServer(restTemplate)
                 .expect(requestUriPath("/alfresco/service/api/solr/metadata"))

--- a/alfresco-webscripts-client/alfresco-webscripts-ditto/src/integration-test/java/eu/xenit/alfresco/webscripts/client/ditto/ApiMetadataFakeClientIntegrationTest.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-ditto/src/integration-test/java/eu/xenit/alfresco/webscripts/client/ditto/ApiMetadataFakeClientIntegrationTest.java
@@ -1,23 +1,23 @@
 package eu.xenit.alfresco.webscripts.client.ditto;
 
-import eu.xenit.alfresco.webscripst.client.ditto.ApiMetadataDittoClient;
-import eu.xenit.alfresco.webscripst.client.ditto.NodeLocatorDittoClient;
+import eu.xenit.alfresco.webscripst.client.ditto.ApiMetadataFakeClient;
+import eu.xenit.alfresco.webscripst.client.ditto.NodeLocatorFakeClient;
 import eu.xenit.alfresco.webscripts.client.spi.ApiMetadataClient;
 import eu.xenit.alfresco.webscripts.client.spi.NodeLocatorClient;
 import eu.xenit.alfresco.webscripts.tests.ApiMetadataClientTests;
 import eu.xenit.testing.ditto.api.AlfrescoDataSet;
 
-class ApiMetadataDittoClientIntegrationTest implements ApiMetadataClientTests
-{
+class ApiMetadataFakeClientIntegrationTest implements ApiMetadataClientTests {
+
     private final AlfrescoDataSet dataSet = AlfrescoDataSet.bootstrapAlfresco().build();
 
     @Override
     public ApiMetadataClient apiMetadataClient() {
-        return new ApiMetadataDittoClient(dataSet);
+        return new ApiMetadataFakeClient(dataSet);
     }
 
     @Override
     public NodeLocatorClient nodeLocatorClient() {
-        return new NodeLocatorDittoClient(dataSet);
+        return new NodeLocatorFakeClient(dataSet);
     }
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-ditto/src/integration-test/java/eu/xenit/alfresco/webscripts/client/ditto/NodeLocatorDittoClientIntegrationTest.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-ditto/src/integration-test/java/eu/xenit/alfresco/webscripts/client/ditto/NodeLocatorDittoClientIntegrationTest.java
@@ -1,13 +1,13 @@
 package eu.xenit.alfresco.webscripts.client.ditto;
 
-import eu.xenit.alfresco.webscripst.client.ditto.NodeLocatorDittoClient;
+import eu.xenit.alfresco.webscripst.client.ditto.NodeLocatorFakeClient;
 import eu.xenit.alfresco.webscripts.client.spi.NodeLocatorClient;
 import eu.xenit.alfresco.webscripts.tests.NodeLocatorClientTests;
 import eu.xenit.testing.ditto.api.AlfrescoDataSet;
 
-class NodeLocatorDittoClientIntegrationTest implements NodeLocatorClientTests
-{
+class NodeLocatorDittoClientIntegrationTest implements NodeLocatorClientTests {
+
     public NodeLocatorClient nodeLocatorClient() {
-        return new NodeLocatorDittoClient(AlfrescoDataSet.bootstrapAlfresco().build());
+        return new NodeLocatorFakeClient(AlfrescoDataSet.bootstrapAlfresco().build());
     }
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-ditto/src/main/java/eu/xenit/alfresco/webscripst/client/ditto/ApiMetadataFakeClient.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-ditto/src/main/java/eu/xenit/alfresco/webscripst/client/ditto/ApiMetadataFakeClient.java
@@ -6,20 +6,22 @@ import eu.xenit.testing.ditto.api.NodeView;
 import eu.xenit.testing.ditto.api.model.ContentData;
 import eu.xenit.testing.ditto.api.model.Node;
 import eu.xenit.testing.ditto.api.model.QName;
-
 import eu.xenit.testing.ditto.util.MimeTypes;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ApiMetadataDittoClient implements ApiMetadataClient {
+public class ApiMetadataFakeClient implements ApiMetadataClient {
 
     private final NodeView nodeView;
 
-    public ApiMetadataDittoClient(AlfrescoDataSet dataSet) {
+    public ApiMetadataFakeClient(AlfrescoDataSet dataSet) {
         this(dataSet.getNodeView());
     }
 
-    public ApiMetadataDittoClient(NodeView nodeView) {
+    public ApiMetadataFakeClient(NodeView nodeView) {
         this.nodeView = nodeView;
     }
 

--- a/alfresco-webscripts-client/alfresco-webscripts-ditto/src/main/java/eu/xenit/alfresco/webscripst/client/ditto/NodeLocatorFakeClient.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-ditto/src/main/java/eu/xenit/alfresco/webscripst/client/ditto/NodeLocatorFakeClient.java
@@ -3,23 +3,19 @@ package eu.xenit.alfresco.webscripst.client.ditto;
 import eu.xenit.alfresco.webscripts.client.spi.NodeLocatorClient;
 import eu.xenit.testing.ditto.api.AlfrescoDataSet;
 import eu.xenit.testing.ditto.api.NodeView;
-import eu.xenit.testing.ditto.api.model.Node;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
-public class NodeLocatorDittoClient implements NodeLocatorClient {
+public class NodeLocatorFakeClient implements NodeLocatorClient {
 
     private final NodeView nodeView;
 
-    public NodeLocatorDittoClient(AlfrescoDataSet dataSet) {
+    public NodeLocatorFakeClient(AlfrescoDataSet dataSet) {
         this(dataSet.getNodeView());
     }
 
-    public NodeLocatorDittoClient(NodeView nodeView) {
+    public NodeLocatorFakeClient(NodeView nodeView) {
         this.nodeView = nodeView;
     }
 

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataClientIntegrationTests.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataClientIntegrationTests.java
@@ -7,20 +7,13 @@ import eu.xenit.alfresco.webscripts.tests.ApiMetadataClientTests;
 
 class ApiMetadataClientIntegrationTests extends WebscriptsSpringClientTestsBase implements ApiMetadataClientTests {
 
-    MetadataApiProperties metadataApiProperties() {
-        return MetadataApiProperties.builder()
-                .host(System.getProperty("alfresco.host", "localhost"))
-                .port(Integer.parseInt(System.getProperty("alfresco.tcp.8080", "8080")))
-                .build();
-    }
-
     @Override
     public ApiMetadataClient apiMetadataClient() {
-        return new ApiMetadataSpringClient(metadataApiProperties(), restTemplateBuilder().build());
+        return new ApiMetadataSpringClient(alfrescoProperties(), restTemplateBuilder().build());
     }
 
     @Override
     public NodeLocatorClient nodeLocatorClient() {
-        return new NodeLocatorSpringClient(restTemplateBuilder().build());
+        return new NodeLocatorSpringClient(alfrescoProperties(), restTemplateBuilder().build());
     }
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataClientIntegrationTests.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataClientIntegrationTests.java
@@ -4,16 +4,35 @@ package eu.xenit.alfresco.webscripts.client.spring;
 import eu.xenit.alfresco.webscripts.client.spi.ApiMetadataClient;
 import eu.xenit.alfresco.webscripts.client.spi.NodeLocatorClient;
 import eu.xenit.alfresco.webscripts.tests.ApiMetadataClientTests;
+import org.junit.jupiter.api.Nested;
 
-class ApiMetadataClientIntegrationTests extends WebscriptsSpringClientTestsBase implements ApiMetadataClientTests {
+class ApiMetadataClientIntegrationTests extends WebscriptsSpringClientTestsBase {
 
-    @Override
-    public ApiMetadataClient apiMetadataClient() {
-        return new ApiMetadataSpringClient(alfrescoProperties(), restTemplateBuilder().build());
+    @Nested
+    class WithProvidedRestTemplate implements ApiMetadataClientTests {
+
+        @Override
+        public ApiMetadataClient apiMetadataClient() {
+            return new ApiMetadataSpringClient(alfrescoProperties());
+        }
+
+        @Override
+        public NodeLocatorClient nodeLocatorClient() {
+            return new NodeLocatorSpringClient(alfrescoProperties());
+        }
     }
 
-    @Override
-    public NodeLocatorClient nodeLocatorClient() {
-        return new NodeLocatorSpringClient(alfrescoProperties(), restTemplateBuilder().build());
+    @Nested
+    class WithCustomRestTemplate implements ApiMetadataClientTests {
+
+        @Override
+        public ApiMetadataClient apiMetadataClient() {
+            return new ApiMetadataSpringClient(alfrescoProperties(), restTemplateBuilder().build());
+        }
+
+        @Override
+        public NodeLocatorClient nodeLocatorClient() {
+            return new NodeLocatorSpringClient(alfrescoProperties(), restTemplateBuilder().build());
+        }
     }
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataClientIntegrationTests.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataClientIntegrationTests.java
@@ -7,9 +7,16 @@ import eu.xenit.alfresco.webscripts.tests.ApiMetadataClientTests;
 
 class ApiMetadataClientIntegrationTests extends WebscriptsSpringClientTestsBase implements ApiMetadataClientTests {
 
+    MetadataApiProperties metadataApiProperties() {
+        return MetadataApiProperties.builder()
+                .host(System.getProperty("alfresco.host", "localhost"))
+                .port(Integer.parseInt(System.getProperty("alfresco.tcp.8080", "8080")))
+                .build();
+    }
+
     @Override
     public ApiMetadataClient apiMetadataClient() {
-        return new ApiMetadataSpringClient(restTemplateBuilder().build());
+        return new ApiMetadataSpringClient(metadataApiProperties(), restTemplateBuilder().build());
     }
 
     @Override

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/NodeLocatorSpringClientIntegrationTests.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/NodeLocatorSpringClientIntegrationTests.java
@@ -9,6 +9,6 @@ class NodeLocatorSpringClientIntegrationTests extends WebscriptsSpringClientTest
 
     @Override
     public NodeLocatorClient nodeLocatorClient() {
-        return new NodeLocatorSpringClient(restTemplateBuilder().build());
+        return new NodeLocatorSpringClient(alfrescoProperties(), restTemplateBuilder().build());
     }
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/NodeLocatorSpringClientIntegrationTests.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/NodeLocatorSpringClientIntegrationTests.java
@@ -3,12 +3,25 @@ package eu.xenit.alfresco.webscripts.client.spring;
 
 import eu.xenit.alfresco.webscripts.client.spi.NodeLocatorClient;
 import eu.xenit.alfresco.webscripts.tests.NodeLocatorClientTests;
+import org.junit.jupiter.api.Nested;
 
-class NodeLocatorSpringClientIntegrationTests extends WebscriptsSpringClientTestsBase implements
-        NodeLocatorClientTests {
+class NodeLocatorSpringClientIntegrationTests extends WebscriptsSpringClientTestsBase {
 
-    @Override
-    public NodeLocatorClient nodeLocatorClient() {
-        return new NodeLocatorSpringClient(alfrescoProperties(), restTemplateBuilder().build());
+    @Nested
+    class WithProvidedRestTemplate implements NodeLocatorClientTests {
+
+        @Override
+        public NodeLocatorClient nodeLocatorClient() {
+            return new NodeLocatorSpringClient(alfrescoProperties());
+        }
+    }
+
+    @Nested
+    class WithCustomRestTemplate implements NodeLocatorClientTests {
+
+        @Override
+        public NodeLocatorClient nodeLocatorClient() {
+            return new NodeLocatorSpringClient(alfrescoProperties());
+        }
     }
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/WebscriptsSpringClientTestsBase.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/integration-test/java/eu/xenit/alfresco/webscripts/client/spring/WebscriptsSpringClientTestsBase.java
@@ -3,10 +3,18 @@ package eu.xenit.alfresco.webscripts.client.spring;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 
 public abstract class WebscriptsSpringClientTestsBase {
+
     protected RestTemplateBuilder restTemplateBuilder() {
         return new RestTemplateBuilder()
                 .basicAuthentication("admin", "admin")
                 .rootUri("http://" + alfrescoHost() + ":" + alfrescoPort() + "/alfresco/service");
+    }
+
+    protected AlfrescoProperties alfrescoProperties() {
+        return AlfrescoProperties.builder()
+                .host(alfrescoHost())
+                .port(alfrescoPort())
+                .build();
     }
 
     private static String alfrescoHost() {

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/AlfrescoProperties.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/AlfrescoProperties.java
@@ -8,7 +8,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class MetadataApiProperties {
+public class AlfrescoProperties {
 
     String url = "http://localhost:8080/alfresco/";
 
@@ -39,8 +39,8 @@ public class MetadataApiProperties {
             return this;
         }
 
-        public MetadataApiProperties build() {
-            return new MetadataApiProperties(this.inner.build().toString());
+        public AlfrescoProperties build() {
+            return new AlfrescoProperties(this.inner.build().toString());
         }
     }
 

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/AlfrescoProperties.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/AlfrescoProperties.java
@@ -10,7 +10,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 @AllArgsConstructor
 public class AlfrescoProperties {
 
-    String url = "http://localhost:8080/alfresco/";
+    private String url = "http://localhost:8080/alfresco/";
+
+    private String user = "admin";
+    private String password = "admin";
 
     public static Builder builder() {
         return new Builder();
@@ -19,6 +22,8 @@ public class AlfrescoProperties {
     public static class Builder {
 
         private UriComponentsBuilder inner = UriComponentsBuilder.fromHttpUrl("http://localhost:8080/alfresco/");
+        private String user = "admin";
+        private String password = "admin";
 
         public Builder scheme(String scheme) {
             this.inner.scheme(scheme);
@@ -39,8 +44,18 @@ public class AlfrescoProperties {
             return this;
         }
 
+        public Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
         public AlfrescoProperties build() {
-            return new AlfrescoProperties(this.inner.build().toString());
+            return new AlfrescoProperties(this.inner.build().toString(), this.user, this.password);
         }
     }
 

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClient.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClient.java
@@ -1,24 +1,30 @@
 package eu.xenit.alfresco.webscripts.client.spring;
 
 import eu.xenit.alfresco.webscripts.client.spi.ApiMetadataClient;
-import java.util.Collections;
-import java.util.Map;
-
+import java.net.URI;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public class ApiMetadataSpringClient implements ApiMetadataClient {
 
     private final RestTemplate restClient;
+    private final String url;
 
-    public ApiMetadataSpringClient(RestTemplate restTemplate) {
+    public ApiMetadataSpringClient(MetadataApiProperties metadataApiProperties, RestTemplate restTemplate) {
+        this.url = UriComponentsBuilder.fromHttpUrl(metadataApiProperties.getUrl())
+                .path("/service/api/metadata")
+                .toUriString();
+
         this.restClient = restTemplate;
     }
 
     @Override
     public Metadata get(String nodeRef) {
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(url)
+                .queryParam("nodeRef", nodeRef)
+                .build().toUri();
 
-        Map<String, String> params = Collections.singletonMap("nodeRef", nodeRef);
-
-        return this.restClient.getForObject("/api/metadata?nodeRef={nodeRef}", Metadata.class, params);
+        return this.restClient.getForObject(uri, Metadata.class);
     }
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClient.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClient.java
@@ -10,6 +10,10 @@ public class ApiMetadataSpringClient implements ApiMetadataClient {
     private final RestTemplate restClient;
     private final String url;
 
+    public ApiMetadataSpringClient(AlfrescoProperties alfrescoProperties) {
+        this(alfrescoProperties, RestTemplateHelper.buildRestTemplate(alfrescoProperties));
+    }
+
     public ApiMetadataSpringClient(AlfrescoProperties alfrescoProperties, RestTemplate restTemplate) {
         this.url = UriComponentsBuilder.fromHttpUrl(alfrescoProperties.getUrl())
                 .path("/service/api/metadata")

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClient.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClient.java
@@ -10,8 +10,8 @@ public class ApiMetadataSpringClient implements ApiMetadataClient {
     private final RestTemplate restClient;
     private final String url;
 
-    public ApiMetadataSpringClient(MetadataApiProperties metadataApiProperties, RestTemplate restTemplate) {
-        this.url = UriComponentsBuilder.fromHttpUrl(metadataApiProperties.getUrl())
+    public ApiMetadataSpringClient(AlfrescoProperties alfrescoProperties, RestTemplate restTemplate) {
+        this.url = UriComponentsBuilder.fromHttpUrl(alfrescoProperties.getUrl())
                 .path("/service/api/metadata")
                 .toUriString();
 

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/MetadataApiProperties.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/MetadataApiProperties.java
@@ -1,0 +1,47 @@
+package eu.xenit.alfresco.webscripts.client.spring;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MetadataApiProperties {
+
+    String url = "http://localhost:8080/alfresco/";
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private UriComponentsBuilder inner = UriComponentsBuilder.fromHttpUrl("http://localhost:8080/alfresco/");
+
+        public Builder scheme(String scheme) {
+            this.inner.scheme(scheme);
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.inner.host(host);
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.inner.port(port);
+            return this;
+        }
+
+        public Builder path(String path) {
+            return this;
+        }
+
+        public MetadataApiProperties build() {
+            return new MetadataApiProperties(this.inner.build().toString());
+        }
+    }
+
+}

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/NodeLocatorSpringClient.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/NodeLocatorSpringClient.java
@@ -20,6 +20,10 @@ public class NodeLocatorSpringClient implements NodeLocatorClient {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final String url;
 
+    public NodeLocatorSpringClient(AlfrescoProperties alfrescoProperties) {
+        this(alfrescoProperties, RestTemplateHelper.buildRestTemplate(alfrescoProperties));
+    }
+
     public NodeLocatorSpringClient(AlfrescoProperties alfrescoProperties, RestTemplate restTemplate) {
         this.url = UriComponentsBuilder.fromHttpUrl(alfrescoProperties.getUrl())
                 .path("/service/api/nodelocator")

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/RestTemplateHelper.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/RestTemplateHelper.java
@@ -1,0 +1,28 @@
+package eu.xenit.alfresco.webscripts.client.spring;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import org.springframework.http.client.support.BasicAuthenticationInterceptor;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+public class RestTemplateHelper {
+
+    private RestTemplateHelper() {
+        // private ctor to hide implicit public one
+    }
+
+    /**
+     * Build a RestTemplate, but side-step all features that use classpath-detection. That gives superfluous errors when
+     * used in environments with a special classloader (e.g. Fusion connector)
+     */
+    public static RestTemplate buildRestTemplate(AlfrescoProperties props) {
+        RestTemplate client = new RestTemplate(Collections.singletonList(
+                new MappingJackson2HttpMessageConverter(new ObjectMapper()))
+        );
+        client.getInterceptors().add(new BasicAuthenticationInterceptor(props.getUser(), props.getPassword()));
+        return client;
+    }
+
+
+}

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/WebscriptHttpErrorResponse.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/main/java/eu/xenit/alfresco/webscripts/client/spring/WebscriptHttpErrorResponse.java
@@ -14,11 +14,11 @@ public class WebscriptHttpErrorResponse {
 
     @Data
     class Status {
+
         private int code;
         private String name;
         private String description;
     }
-
 
 
 }

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
@@ -30,7 +30,7 @@ class ApiMetadataSpringClientTest {
         final String nodeRef = UUID.randomUUID().toString();
 
         RestTemplate restTemplate = new RestTemplateBuilder().build();
-        ApiMetadataClient client = new ApiMetadataSpringClient(new MetadataApiProperties(), restTemplate);
+        ApiMetadataClient client = new ApiMetadataSpringClient(new AlfrescoProperties(), restTemplate);
 
         MockRestServiceServer.createServer(restTemplate)
                 .expect(requestUriPath("/alfresco/service/api/metadata"))

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
@@ -1,0 +1,72 @@
+package eu.xenit.alfresco.webscripts.client.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+import static org.springframework.test.util.AssertionErrors.fail;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import eu.xenit.alfresco.webscripts.client.spi.ApiMetadataClient;
+import eu.xenit.alfresco.webscripts.client.spi.ApiMetadataClient.Metadata;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.RequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+class ApiMetadataSpringClientTest {
+
+    @Test
+    void getMetadata() {
+        final String nodeRef = UUID.randomUUID().toString();
+
+        RestTemplate restTemplate = new RestTemplateBuilder().build();
+        ApiMetadataClient client = new ApiMetadataSpringClient(restTemplate);
+
+        MockRestServiceServer.createServer(restTemplate)
+                .expect(requestUriPath("/api/metadata"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(queryParam("nodeRef", nodeRef))
+
+                .andRespond(withSuccess(
+                        "{" +
+                                "\"nodeRef\": \"" + nodeRef + "\"" +
+                        "}", MediaType.APPLICATION_JSON));
+
+        Metadata result = client.get(nodeRef);
+        assertThat(result)
+                .isNotNull()
+                .satisfies(metadata -> assertThat(metadata.getNodeRef())
+                        .isEqualTo(nodeRef));
+    }
+
+    private static RequestMatcher requestUriPath(String expectedPath) {
+        Assert.notNull(expectedPath, "'expectedPath' must not be null");
+        return request -> assertEquals("Request URI path", expectedPath, request.getURI().getPath());
+    }
+
+    private static RequestMatcher queryParamDoesNotExists(String queryParam) {
+        Assert.notNull(queryParam, "'queryParam' must not be null");
+        return request -> {
+            List<String> queryParamValues = getQueryParams(request).get(queryParam);
+            if (queryParamValues != null) {
+                fail("Expected query-param <" + queryParam + "> not to exist, but it exists with values: "
+                        + queryParamValues + " in " + request.getURI());
+            }
+        };
+    }
+
+    private static MultiValueMap<String, String> getQueryParams(ClientHttpRequest request) {
+        return UriComponentsBuilder.fromUri(request.getURI()).build().getQueryParams();
+    }
+
+}

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
@@ -30,17 +30,18 @@ class ApiMetadataSpringClientTest {
         final String nodeRef = UUID.randomUUID().toString();
 
         RestTemplate restTemplate = new RestTemplateBuilder().build();
-        ApiMetadataClient client = new ApiMetadataSpringClient(restTemplate);
+        ApiMetadataClient client = new ApiMetadataSpringClient(new MetadataApiProperties(), restTemplate);
 
         MockRestServiceServer.createServer(restTemplate)
-                .expect(requestUriPath("/api/metadata"))
+                .expect(requestUriPath("/alfresco/service/api/metadata"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(queryParam("nodeRef", nodeRef))
 
                 .andRespond(withSuccess(
                         "{" +
                                 "\"nodeRef\": \"" + nodeRef + "\"" +
-                        "}", MediaType.APPLICATION_JSON));
+                                // TODO expand
+                                "}", MediaType.APPLICATION_JSON));
 
         Metadata result = client.get(nodeRef);
         assertThat(result)

--- a/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
+++ b/alfresco-webscripts-client/alfresco-webscripts-spring/src/test/java/eu/xenit/alfresco/webscripts/client/spring/ApiMetadataSpringClientTest.java
@@ -39,15 +39,34 @@ class ApiMetadataSpringClientTest {
 
                 .andRespond(withSuccess(
                         "{" +
-                                "\"nodeRef\": \"" + nodeRef + "\"" +
-                                // TODO expand
+                                "\"nodeRef\":\"" + nodeRef + "\"," +
+                                "\"aspects\":[" +
+                                "\"{http://www.alfresco.org/model/content/1.0}titled\"," +
+                                "\"{http://www.alfresco.org/model/content/1.0}auditable\"," +
+                                "\"{http://www.alfresco.org/model/system/1.0}referenceable\"" +
+                                "]," +
+                                "\"mimetype\":\"application/octet-stream\"," +
+                                "\"type\":\"{http://www.alfresco.org/model/content/1.0}folder\"," +
+                                "\"properties\":{" +
+                                "\"{http://www.alfresco.org/model/content/1.0}created\":\"2020-02-24T08:04:36.613Z\"," +
+                                "\"{http://www.alfresco.org/model/content/1.0}title\":\"Company Home\"," +
+                                "\"{http://www.alfresco.org/model/content/1.0}description\":\"The company root space\""
+                                + "}" +
                                 "}", MediaType.APPLICATION_JSON));
 
         Metadata result = client.get(nodeRef);
         assertThat(result)
                 .isNotNull()
-                .satisfies(metadata -> assertThat(metadata.getNodeRef())
-                        .isEqualTo(nodeRef));
+                .satisfies(m -> assertThat(m.getNodeRef()).isEqualTo(nodeRef))
+                .satisfies(m -> assertThat(m.getMimetype()).isEqualTo("application/octet-stream"))
+                .satisfies(m -> assertThat(m.getType()).isEqualTo("{http://www.alfresco.org/model/content/1.0}folder"))
+                .satisfies(m -> assertThat(m.getAspects()).contains(
+                        "{http://www.alfresco.org/model/content/1.0}titled",
+                        "{http://www.alfresco.org/model/content/1.0}auditable",
+                        "{http://www.alfresco.org/model/system/1.0}referenceable"
+                ))
+                .satisfies(m -> assertThat(m.getProperties())
+                        .containsEntry("{http://www.alfresco.org/model/content/1.0}title", "Company Home"));
     }
 
     private static RequestMatcher requestUriPath(String expectedPath) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'eu.xenit.alfresco.client'
-version = '0.0.4-SNAPSHOT'
+version = '0.0.5-SNAPSHOT'
 
 subprojects {
     pluginManager.withPlugin('java-library') {


### PR DESCRIPTION
- Naming conventions: 
    - renamed `SolrAPIClientImpl` to `SolrApiSpringClient`
    - renamed `...DittoClient` to `...FakeClient`.

- Usage conventions:
    - `ApiMetadataSpringClient` and `NodeLocatorClient` relied on a `RestTemplate` with base url: `${protcol}://${host}:${port}/alfresco/s`, `SolrAPIClientImpl` needed a `RestTemplate` without base url. This has now been aligned to the latter behavior. 

- Also include a unit test for the `ApiMetadataSpringClient` 
