### PR TITLE
Interface change: AclChangeSetList instead of List<AclChangeSet>

### DIFF
--- a/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/main/java/eu/xenit/alfresco/solrapi/client/ditto/SolrApiFakeClient.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-ditto/src/main/java/eu/xenit/alfresco/solrapi/client/ditto/SolrApiFakeClient.java
@@ -4,6 +4,7 @@ package eu.xenit.alfresco.solrapi.client.ditto;
 import eu.xenit.alfresco.solrapi.client.spi.SolrApiClient;
 import eu.xenit.alfresco.solrapi.client.spi.dto.Acl;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AclChangeSet;
+import eu.xenit.alfresco.solrapi.client.spi.dto.AclChangeSetList;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AclReaders;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AlfrescoModel;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AlfrescoModelDiff;
@@ -59,7 +60,7 @@ public class SolrApiFakeClient implements SolrApiClient {
     }
 
     @Override
-    public List<AclChangeSet> getAclChangeSets(Long fromId, Long fromTime, int maxResults) {
+    public AclChangeSetList getAclChangeSets(Long fromId, Long fromTime, int maxResults) {
         return null;
     }
 

--- a/alfresco-solrapi-client/alfresco-solrapi-client-spi/src/main/java/eu/xenit/alfresco/solrapi/client/spi/SolrApiClient.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-spi/src/main/java/eu/xenit/alfresco/solrapi/client/spi/SolrApiClient.java
@@ -27,6 +27,7 @@ package eu.xenit.alfresco.solrapi.client.spi;
 
 import eu.xenit.alfresco.solrapi.client.spi.dto.Acl;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AclChangeSet;
+import eu.xenit.alfresco.solrapi.client.spi.dto.AclChangeSetList;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AclReaders;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AlfrescoModel;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AlfrescoModelDiff;
@@ -53,7 +54,7 @@ import java.util.List;
  */
 public interface SolrApiClient {
 
-    public List<AclChangeSet> getAclChangeSets(Long fromId, Long fromTime, int maxResults);
+    public AclChangeSetList getAclChangeSets(Long fromId, Long fromTime, int maxResults);
 
     List<Acl> getAcls(AclsQueryParameters parameters);
 

--- a/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/main/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClient.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-client-spring/src/main/java/eu/xenit/alfresco/solrapi/client/spring/SolrApiSpringClient.java
@@ -87,7 +87,7 @@ public class SolrApiSpringClient implements SolrApiClient {
 
 
     @Override
-    public List<AclChangeSet> getAclChangeSets(Long fromId, Long fromTime, int maxResults) {
+    public AclChangeSetList getAclChangeSets(Long fromId, Long fromTime, int maxResults) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(url).path("/aclchangesets");
         conditionalQueryParam(uriBuilder, "fromId", fromId, Objects::nonNull);
         conditionalQueryParam(uriBuilder, "fromTime", fromTime, Objects::nonNull);
@@ -95,7 +95,7 @@ public class SolrApiSpringClient implements SolrApiClient {
                 val != Integer.valueOf(0) && val != Integer.valueOf(Integer.MAX_VALUE));
 
         AclChangeSetList response = restTemplate.getForObject(uriBuilder.toUriString(), AclChangeSetList.class);
-        return response.getAclChangeSets();
+        return response;
     }
 
     @Override

--- a/alfresco-solrapi-client/alfresco-solrapi-integration-tests/src/main/java/eu/xenit/alfresco/solrapi/client/tests/GetAclChangeSetsIntegrationTests.java
+++ b/alfresco-solrapi-client/alfresco-solrapi-integration-tests/src/main/java/eu/xenit/alfresco/solrapi/client/tests/GetAclChangeSetsIntegrationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import eu.xenit.alfresco.solrapi.client.spi.SolrApiClient;
 import eu.xenit.alfresco.solrapi.client.spi.dto.AclChangeSet;
+import eu.xenit.alfresco.solrapi.client.spi.dto.AclChangeSetList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -15,8 +16,8 @@ public interface GetAclChangeSetsIntegrationTests {
 
         SolrApiClient client = solrApiClient();
 
-        List<AclChangeSet> changesets = client.getAclChangeSets(1L, null, 1);
-        assertThat(changesets)
+        AclChangeSetList changesets = client.getAclChangeSets(1L, null, 1);
+        assertThat(changesets.getAclChangeSets())
                 .hasOnlyOneElementSatisfying(changeset -> {
                     assertThat(changeset.getId()).isEqualTo(1);
                     assertThat(changeset.getAclCount()).isEqualTo(2);


### PR DESCRIPTION
For getAclChangeSets return AclChangeSetList instead of List<AclChangeSet>, because it contains useful additional information about maxChangeSetCommitTime and maxChangeSetId besides the list of changesets.